### PR TITLE
fix(x86_64): set alignment to 16 bytes

### DIFF
--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -16,7 +16,7 @@ signal_trampoline:
 "
 );
 
-#[repr(C)]
+#[repr(C, align(16))]
 #[derive(Clone)]
 pub struct MContext {
     r8: usize,


### PR DESCRIPTION
Test case
```c
#include <stdio.h>
#include <signal.h>
#include <stdlib.h>
#include <stdint.h>
#include <xmmintrin.h> // For SSE types and intrinsics

// Use volatile to prevent optimization from removing the check
void handler(int signo) {
    uint64_t rsp_val;
    asm volatile ("mov %%rsp, %0" : "=r"(rsp_val));
    
    printf("[*] Signal Handler Entered. Signal: %d\n", signo);
    printf("[*] RSP at handler body check: 0x%lx\n", rsp_val);

    // On x86_64, __m128 requires 16-byte alignment.
    // The compiler assumes the stack is properly aligned to place this variable.
    volatile __m128 vec;
    
    // Initialize to ensure instructions are generated
    vec = _mm_set1_ps(3.14f);

    uintptr_t addr = (uintptr_t)&vec;
    printf("[*] Address of __m128 local variable: 0x%lx\n", addr);
    
    exit(0);
}

int main() {
    printf("[*] stack_align_test: Registering signal handler for SIGUSR1...\n");
    if (signal(SIGUSR1, handler) == SIG_ERR) {
        perror("signal");
        return 1;
    }

    printf("[*] Raising SIGUSR1...\n");
    raise(SIGUSR1);

    // Should not reach here
    printf("[-] FAIL: Main function continued after handler (handler should have exited).\n");
    return 1;
}
```
Output：
```bash
starryos~# ./stack_align_test 
[*] stack_align_test: Registering signal handler for SIGUSR1...
[*] Raising SIGUSR1...
[*] Signal Handler Entered. Signal: 10
[*] RSP at handler body check: 0x7ffefffffae8
Trace/breakpoint trap (core dumped)
```


